### PR TITLE
Bugfix - CR register cannot be updated properly

### DIFF
--- a/include/eris/low/7up.h
+++ b/include/eris/low/7up.h
@@ -30,6 +30,13 @@ typedef enum {
  * \param chip Which 7up to initialize. (0 ~ 1)
  */
 void eris_low_sup_init(int chip);
+/*! \brief Set a 7up register to a value
+ *
+ * \param chip Which 7up to initialize. (0 ~ 1)
+ * \param reg Which 7up register to initialize. (0 ~ 0x13)
+ * \param value The value to set it to (0 ~ 0xFFFF)
+ */
+void eris_low_sup_setreg(int chip, int reg, int value);
 /*! \brief Setup a 7up's video mode.
  *
  * \param chip Which 7up to configure. (0 ~ 1)

--- a/src/low/7up.S
+++ b/src/low/7up.S
@@ -11,6 +11,7 @@ Copyright (C) 2011              Alex Marshall "trap15" <trap15@raidenii.net>
  *  Low-level 7up functions                                              []  *
  *****************************************************************************/
 	.global	_eris_low_sup_init
+	.global	_eris_low_sup_setreg
 	.global	_eris_low_sup_set_video_mode
 	.global	_eris_low_sup_get_video_mode
 	.global	_eris_low_sup_set_vram_write
@@ -63,6 +64,12 @@ _eris_low_sup_init:
 	out.h	r0, 4[r10]
 	cmp	5, r8
 	bne	2b
+	jmp	[lp]
+
+_eris_low_sup_setreg:
+	shl	8, r6
+	set_rrg	r7, r6, r10
+	out.h	r8, 4[r10]
 	jmp	[lp]
 
 _eris_low_sup_set_video_mode:


### PR DESCRIPTION
In the original API, the 7up CR register could *either* update whether BG/SP are showing, *OR* enable interrupts, but not both.  If one was set, the other would suffer.

This adds a eris_low_sup_setreg() function which allows to set a register's value directly, rather than piecemeal, avoiding that pitfall.