### PR TITLE
Correct usage of "data ready" during pad read

### DIFF
--- a/src/low/pad.S
+++ b/src/low/pad.S
@@ -31,11 +31,19 @@ _eris_low_pad_read_status:
 
 _eris_low_pad_read_data:
 	shl	7, r6
-	mov	5, r10
+	mov	7, r10		/* reset multitap and request data from pad */
 	out.h	r10, 0[r6]
-	in.w	0x40[r6], r10
+
+wait_for_input_ready:
+        in.h	0[r6], r10	/* r10 is now the status register value */
+        andi	9, r10, r10
+        cmp	1, r10
+        bz	wait_for_input_ready
+
+	in.w	0x40[r6], r10	/* and now r10 is the pad data value */
 	jmp	[lp]
 
+/* This function seems to be of no use */
 _eris_low_pad_data_ready:
 	shl	7, r6
 	in.h	0[r6], r10

--- a/src/pad.S
+++ b/src/pad.S
@@ -39,19 +39,10 @@ _eris_pad_read:
 	movea	lo(eris_pad_states), r15, r15
 	add	r16, r15
 
-	jal	_eris_low_pad_data_ready
-	cmp	0, r10
-	be	1f
-
 	mov	r17, r6
 	jal	_eris_low_pad_read_data
 	st.w	r10, 0[r15]
-	br	2f
 
-1:	ld.w	0[r15], r10
-2:	movhi	0x1000, r0, r11
-	add	-1, r11
-	and	r11, r10
 	mov	r18, lp
 	jmp	[lp]
 
@@ -65,16 +56,11 @@ _eris_pad_type:
 	movea	lo(eris_pad_states), r15, r15
 	add	r16, r15
 
-	jal	_eris_low_pad_data_ready
-	cmp	0, r10
-	be	1f
-
 	mov	r17, r6
 	jal	_eris_low_pad_read_data
 	st.w	r10, 0[r15]
 	br	2f
 
-1:	ld.w	0[r15], r10
 2:	shr	28, r10
 	mov	r18, lp
 	jmp	[lp]


### PR DESCRIPTION
Various fixes:
1) Remove extraneous check for data ready which was useless
2) Ensure that after a request is made, that data is ready before it is read
3) Since this is a single-pad read, send reset signal when scanning (multitap code to come later)